### PR TITLE
Add repository-backed chat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ byte[] data = blocks.get(0).block;
 ### Demo app
 If you want a working example app you can fork, have a look at our [chat example](https://github.com/Peergos/nabu-chat). This is a simple CLI app where two users exchange peerid (out of band) and then connect and send messages via p2p http requests, which are printed to the console.
 
+For a minimal illustration bundled with this repository, check `org.peergos.examples.chat.RepositoryChatExample`. It creates a lightweight chat conversation that persists messages in local IPFS blockstores using the repository pattern. You can run it with:
+
+```
+mvn -q -DskipTests compile exec:java -Dexec.mainClass=org.peergos.examples.chat.RepositoryChatExample
+```
+
 ### S3 Blockstore
 
 By default, Nabu will construct a File based blockstore

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/org/peergos/examples/chat/ChatMessage.java
+++ b/src/main/java/org/peergos/examples/chat/ChatMessage.java
@@ -1,0 +1,68 @@
+package org.peergos.examples.chat;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Value object representing a message in the repository backed chat example.
+ */
+public class ChatMessage {
+
+    private final String sender;
+    private final Instant timestamp;
+    private final String content;
+
+    public ChatMessage(String sender, Instant timestamp, String content) {
+        this.sender = Objects.requireNonNull(sender, "sender");
+        this.timestamp = Objects.requireNonNull(timestamp, "timestamp");
+        this.content = Objects.requireNonNull(content, "content");
+    }
+
+    public String getSender() {
+        return sender;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    /**
+     * Serialises this message to a stable byte representation that can be stored in a blockstore.
+     */
+    public byte[] toBytes() {
+        String base64Content = Base64.getEncoder().encodeToString(content.getBytes(StandardCharsets.UTF_8));
+        String serialised = sender + "\n" + timestamp.toString() + "\n" + base64Content;
+        return serialised.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Restores a {@link ChatMessage} from its serialised representation produced by {@link #toBytes()}.
+     */
+    public static ChatMessage fromBytes(byte[] data) {
+        Objects.requireNonNull(data, "data");
+        String serialised = new String(data, StandardCharsets.UTF_8);
+        String[] parts = serialised.split("\n", 3);
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("Invalid chat message encoding");
+        }
+        try {
+            Instant timestamp = Instant.parse(parts[1]);
+            String content = new String(Base64.getDecoder().decode(parts[2]), StandardCharsets.UTF_8);
+            return new ChatMessage(parts[0], timestamp, content);
+        } catch (DateTimeParseException | IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Invalid chat message encoding", ex);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "[" + timestamp + "] " + sender + ": " + content;
+    }
+}

--- a/src/main/java/org/peergos/examples/chat/ChatRepository.java
+++ b/src/main/java/org/peergos/examples/chat/ChatRepository.java
@@ -1,0 +1,52 @@
+package org.peergos.examples.chat;
+
+import io.ipfs.cid.Cid;
+import org.peergos.blockstore.Blockstore;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Simple repository abstraction that persists chat messages inside an IPFS {@link Blockstore}.
+ */
+public class ChatRepository {
+
+    private final Blockstore blockstore;
+    private final Clock clock;
+
+    public ChatRepository(Blockstore blockstore, Clock clock) {
+        this.blockstore = Objects.requireNonNull(blockstore, "blockstore");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    /**
+     * Stores the message content in the blockstore and returns the generated {@link Cid}.
+     */
+    public Cid save(String sender, String message) {
+        ChatMessage chatMessage = new ChatMessage(sender, clock.instant(), message);
+        return blockstore.put(chatMessage.toBytes(), Cid.Codec.Raw).join();
+    }
+
+    /**
+     * Retrieves a message from the blockstore.
+     */
+    public Optional<ChatMessage> find(Cid cid) {
+        return blockstore.get(cid)
+                .join()
+                .map(ChatMessage::fromBytes);
+    }
+
+    /**
+     * Loads a conversation using a list of message identifiers.
+     */
+    public List<ChatMessage> loadConversation(List<Cid> messageIds) {
+        List<ChatMessage> messages = new ArrayList<>();
+        for (Cid messageId : messageIds) {
+            find(messageId).ifPresent(messages::add);
+        }
+        return messages;
+    }
+}

--- a/src/main/java/org/peergos/examples/chat/RepositoryChatExample.java
+++ b/src/main/java/org/peergos/examples/chat/RepositoryChatExample.java
@@ -1,0 +1,88 @@
+package org.peergos.examples.chat;
+
+import io.ipfs.cid.Cid;
+import org.peergos.blockstore.FileBlockstore;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Entry point showcasing how to build a repository backed chat on top of the local IPFS blockstore APIs.
+ *
+ * <p>The example creates a repository for each participant (Alice and Bob) and stores their messages.
+ * The messages are persisted in a {@link org.peergos.blockstore.Blockstore} implementation, returning a
+ * {@link Cid} for each entry that can be exchanged over any transport layer.</p>
+ */
+public final class RepositoryChatExample {
+
+    private RepositoryChatExample() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("Starting repository-backed chat example\n");
+
+        Path aliceRepositoryPath = Files.createTempDirectory("alice-chat-repo");
+        Path bobRepositoryPath = Files.createTempDirectory("bob-chat-repo");
+
+        try {
+            FileBlockstore aliceBlockstore = new FileBlockstore(aliceRepositoryPath);
+            FileBlockstore bobBlockstore = new FileBlockstore(bobRepositoryPath);
+
+            ChatRepository aliceRepository = new ChatRepository(aliceBlockstore, Clock.systemUTC());
+            ChatRepository bobRepository = new ChatRepository(bobBlockstore, Clock.systemUTC());
+
+            List<Cid> conversationIds = new ArrayList<>();
+
+            Cid greetingId = aliceRepository.save("Alice", "Olá Bob! Este é um exemplo de chat usando um repositório IPFS.");
+            conversationIds.add(greetingId);
+            System.out.println("Alice armazenou a mensagem " + greetingId);
+
+            Cid replyId = bobRepository.save("Bob", "Oi Alice! Consigo ler sua mensagem usando o identificador gerado.");
+            conversationIds.add(replyId);
+            System.out.println("Bob armazenou a mensagem " + replyId);
+
+            Cid followUpId = aliceRepository.save("Alice", "Perfeito! Podemos compartilhar apenas os CIDs para reconstruir a conversa.");
+            conversationIds.add(followUpId);
+            System.out.println("Alice armazenou a mensagem " + followUpId + "\n");
+
+            List<ChatMessage> recoveredMessages = new ArrayList<>();
+            recoveredMessages.addAll(aliceRepository.loadConversation(conversationIds));
+            recoveredMessages.addAll(bobRepository.loadConversation(conversationIds));
+
+            recoveredMessages.sort((left, right) -> left.getTimestamp().compareTo(right.getTimestamp()));
+
+            System.out.println("Transcrição completa usando o repositório local:\n");
+            for (ChatMessage message : recoveredMessages) {
+                System.out.println(message);
+            }
+        } finally {
+            deleteRecursively(aliceRepositoryPath);
+            deleteRecursively(bobRepositoryPath);
+        }
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(path)) {
+            walk.sorted(Comparator.reverseOrder())
+                    .forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                        } catch (IOException ex) {
+                            throw new UncheckedIOException(ex);
+                        }
+                    });
+        } catch (UncheckedIOException ex) {
+            throw ex.getCause();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a repository-backed chat example that persists messages in the local blockstore
- expose supporting ChatMessage and ChatRepository helpers for serialising and retrieving messages
- document how to run the example and wire the exec-maven-plugin so the command works out of the box

## Testing
- mvn -DskipTests compile
- mvn -DskipTests exec:java -Dexec.mainClass=org.peergos.examples.chat.RepositoryChatExample

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691095b24fc88332bb5ffbe63452c2bc)